### PR TITLE
Add python/gradio_app/gradio constructed by envagent to the multi-swe-bench - 20250801_021557

### DIFF
--- a/multi_swe_bench/harness/repos/python/__init__.py
+++ b/multi_swe_bench/harness/repos/python/__init__.py
@@ -57,3 +57,5 @@ from multi_swe_bench.harness.repos.python.qiskit import *
 from multi_swe_bench.harness.repos.python.networkx import *
 from multi_swe_bench.harness.repos.python.plotly import *
 from multi_swe_bench.harness.repos.python.vega import *
+from multi_swe_bench.harness.repos.python.great_expectations import *
+from multi_swe_bench.harness.repos.python.hdmf_dev import *


### PR DESCRIPTION
add {language}/{org_dirname}/{repo_name} constructed by envagent to the multi-swe-bench.